### PR TITLE
Add app.txt so that notebook can be launched via mybinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# go-handbook
+Electronic exercises (with solutions) to accompany the book chapter "A Gene Ontology Tutorial in Python" by Alex Warwick Vesztrocy and Christophe Dessimoz, in the collection The Gene Ontology Handbook, C Dessimoz and N Skunca Eds, Spring Humana.
+
+## Launch binder
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/BioGeek/go-handbook/master?filepath=GO%20Tutorial%20in%20Python%20-%20Exercises.ipynb)

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,4 @@
+python-dev
+graphviz
+libgraphviz-dev
+pkg-config


### PR DESCRIPTION
Right now, if you try to open the notebook via [mybinder.org](https://mybinder.org/), you get an error

    No package 'libcgraph' found

This is because `libgraphviz-dev` and related dependencies needs to be installed first. This pull request adds a simple `app.txt`file with the required dependencies.

This now allows to place a 'Launch binder` button in your README, which allows anyone to open your notebooks directly in an interactive environment.

You can test the binder from my repository here:  [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/BioGeek/go-handbook/master?filepath=GO%20Tutorial%20in%20Python%20-%20Exercises.ipynb)


